### PR TITLE
2025-03-02 [Greedy][C++] 1911. 흙길 보수하기 제출

### DIFF
--- a/BOJ/1911. 흙길 청소하기/soyoung_main.cpp
+++ b/BOJ/1911. 흙길 청소하기/soyoung_main.cpp
@@ -1,0 +1,39 @@
+#include <bits/stdc++.h>
+using namespace std;
+int result;
+int N, L;
+int st, en;
+priority_queue<pair<int, int>> ponds;
+int lastBoard = INT32_MAX;
+
+void inputData();
+void solution();
+
+int main() {
+	inputData();
+	solution();
+	cout << result << endl;
+}
+
+void inputData() {
+	ios::sync_with_stdio(false);
+	cin.tie(NULL);
+	cin >> N >> L;
+	for (int i = 0; i < N; ++i) {
+		cin >> st >> en;
+		ponds.push({ en, st });
+	}
+	
+
+}
+
+void solution() {
+	while (!ponds.empty()) {
+		pair<int, int> currentPond = ponds.top();
+		ponds.pop();
+		lastBoard = lastBoard > currentPond.first ? currentPond.first : lastBoard;
+		int cnt = ceil((double)(lastBoard - currentPond.second) / (double)L);
+		result += cnt;
+		lastBoard -= cnt * L;
+	}
+}


### PR DESCRIPTION
단순 그리디 문제.

* 웅덩이의 끝이 정해져있있지 않은 문제에는 끝이 큰 값부터 sort해주면 빠르게 풀 수 있다. 
* priority_queue<pair<int, int>> 이기 때문에, pair의 first에는 웅덩이의 끝, second에는 웅덩이의 시작을 넣었다.
* priority queue는 자동으로 정렬이 되고(트리의 특성) first가 같으면 second를 비교해주기 때문에 편한 한편, 시간복잡도도 효율적이다! 
* 웅덩이의 끝값이 조금 헷갈렸는데, 괜히 값을 하나를 빼야 할 것 같지만 그렇지 않았다.

메모리 : 2288, 시간 : 4ms, 풀이 시간 : 30M ~ 1H.