### PR TITLE
[2025-05-11] [C++] 부대복귀, 연산자 끼워넣기, 음악프로그램 풀이

### DIFF
--- a/BOJ/14888. 연산자 끼워넣기/jeongbin_main.cpp
+++ b/BOJ/14888. 연산자 끼워넣기/jeongbin_main.cpp
@@ -1,0 +1,44 @@
+#if 0
+#include <iostream>
+using namespace std;
+
+int n, a, cnt, mn = INT32_MAX, mx = INT32_MIN;
+int arr[4], num[12];
+
+void combi(int idx, int ret) {
+    if (idx == n) {
+        mn = min(mn, ret);
+        mx = max(mx, ret);
+        return;
+    }
+	for (int i = 0; i < 4; i++) { // 각 연산자별 완탐 수행
+        if (arr[i] > 0) {
+            arr[i]--; // 연산자 개수 --
+            if (i == 0) combi(idx + 1, ret + num[idx]);
+            else if (i == 1) combi(idx + 1, ret - num[idx]);
+            else if (i == 2) combi(idx + 1, ret * num[idx]);
+            else if (i == 3) combi(idx + 1, ret / num[idx]);
+            arr[i]++; // 연산자 개수 ++
+        }
+	}
+}
+
+int main() {
+
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL); cout.tie(NULL);
+
+	cin >> n;
+    for (int i = 0; i < n; i++) { // 계산할 숫자 입력
+        cin >> num[i];
+    }
+	for (int i = 0; i < 4; i++) { // 각 연산자 수 입력
+		cin >> arr[i];
+	}
+
+    combi(1, num[0]);
+    cout << mx << '\n' << mn;
+	return 0;
+}
+
+#endif // 01

--- a/BOJ/2623. 음악프로그램/jeongbin_main.cpp
+++ b/BOJ/2623. 음악프로그램/jeongbin_main.cpp
@@ -1,0 +1,143 @@
+#if 01
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+
+int n, m;
+vector<int> graph[1004];
+int input_cnt[1004];
+vector<int> ans;
+
+int solution() {
+	
+	// 진입 순서가 0인 노드를 tmp에 넣음
+	vector<int> tmp;
+	for (int i = 1; i <= n; i++) {
+		if (input_cnt[i] == 0) {
+			tmp.push_back(i);
+		}
+	}
+
+	while (!tmp.empty()) {
+		int here = tmp.back();
+		tmp.pop_back();
+		ans.push_back(here);
+
+		for (int there : graph[here]) {
+			input_cnt[there]--;
+			if (input_cnt[there] == 0) {
+				tmp.push_back(there);
+			}
+		}
+	}
+
+	// 사이클 or 모든 노드가 담기지 못한 경우
+	if (ans.size() != n) return 0;
+
+	return 1;
+}
+
+int main() {
+
+	cin >> n >> m;
+	for (int i = 0; i < m; i++) {
+		int num, prev = 0;
+		cin >> num;
+		for (int j = 0; j < num; j++) { // 들어가야 하는 순서 확인을 위해 graph 구성
+			int x;
+			cin >> x;
+			if (j > 0) {
+				graph[prev].push_back(x);  // prev -> x 간선 추가
+				input_cnt[x]++;
+			}
+			prev = x;
+		}
+	}
+
+	int ret = solution();
+	if (ret == 0) cout << 0;
+	else {
+		for (int i : ans) {
+			cout << i << '\n';
+		}
+	}
+
+	return 0;
+}
+
+#endif
+
+#if 0
+
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+using namespace std;
+
+int n, m;
+vector<int> graph[1004];
+int input_cnt[1004];
+
+vector<int> ans;
+
+int solution() {
+
+	// 진입 순서가 0인 노드를 tmp에 넣음
+	queue<int> tmp;
+	for (int i = 1; i <= n; i++) {
+		if (input_cnt[i] == 0) {
+			tmp.push(i);
+		}
+	}
+
+	while (tmp.size()) {
+		int here = tmp.front();
+		tmp.pop();
+		ans.push_back(here);
+
+		for (int there : graph[here]) {
+			input_cnt[there]--;
+			if (input_cnt[there] == 0) {
+				tmp.push(there);
+			}
+		}
+	}
+
+	// 사이클 or 모든 노드가 담기지 못한 경우
+	if (ans.size() != n) return 0;
+
+	return 1;
+}
+
+int main() {
+
+	cin >> n >> m;
+	for (int i = 0; i < m; i++) {
+		int num, prev = 0;
+		cin >> num;
+		for (int j = 0; j < num; j++) { // 들어가야 하는 순서 확인을 위해 graph 구성
+			int x;
+			cin >> x;
+			if (j > 0) {
+				graph[prev].push_back(x);  // prev -> x 간선 추가
+				input_cnt[x]++;
+			}
+			prev = x;
+		}
+	}
+
+	int ret = solution();
+	if (ret == 0) cout << 0;
+	else {
+		for (int i : ans) {
+			cout << i << '\n';
+		}
+	}
+
+	return 0;
+}
+
+#endif

--- a/Programmers/부대복귀/jeongbin_main.cpp
+++ b/Programmers/부대복귀/jeongbin_main.cpp
@@ -1,0 +1,57 @@
+#if 0
+#include <string>
+#include <vector>
+#include <queue>
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int visited[100004];
+vector<int> map[100004];
+vector<int> ret;
+
+void bfs(vector<int> sources, int dest) {
+    queue<pair<int, int>> q; // 우선순위  큐 사용 시 시간초과 남.
+    q.push({ 0, dest });
+    visited[dest] = 0;
+    while (q.size()) {
+        int here = q.front().second;
+        int sec = q.front().first;
+        q.pop();
+        //cout<<here<<": "<<sec<<'\n';
+        // auto pos = find(sources.begin(), sources.end(), here);
+        // if( pos != sources.end()){
+        //     visited[here] = sec;
+        //     sources.erase(pos);
+        //     continue;
+        // }
+        if (visited[here] < sec) continue;
+        for (int there : map[here]) {
+            int next_sec = sec + 1;
+            //cout<<there<<": "<<next_sec<<'\n';
+            if (next_sec > visited[there]) continue;
+            //cout<<there<<": "<<next_sec<<'\n';
+            visited[there] = next_sec;
+            q.push({ next_sec, there });
+        }
+    }
+}
+
+// 총 지역수, 길 정보(왕복), 위치한 서로 다른 지역(출발지), 부대의 지역(목적지)
+vector<int> solution(int n, vector<vector<int>> roads, vector<int> sources, int destination) {
+    vector<int> answer;
+
+    for (int i = 0; i < roads.size(); i++) {
+        map[roads[i][0]].push_back(roads[i][1]);
+        map[roads[i][1]].push_back(roads[i][0]);
+    }
+    fill(visited, visited + 100004, INT32_MAX);
+    bfs(sources, destination);
+    for (int i = 0; i < sources.size(); i++) {
+        if (visited[sources[i]] == INT32_MAX) answer.push_back(-1);
+        else answer.push_back(visited[sources[i]]);
+    }
+
+    return answer;
+}
+#endif // 0


### PR DESCRIPTION
> 부대복귀
- 처음 풀이할 때 우선순위 큐를 사용하니 시간초과가 발생하여 큐를 사용하였습니다.
- 기본 큐를 사용하였지만 풀이 자체는 다익스트라 알고리즘처럼 각 노드에 도착하는 시간이 최소가 되도록 하였습니다.
- 모든 출발지에서의 경우를 확인하지 않고 목적지에서 1번만 탐색하여 각 출발지까지의 시간을 구하는 방식을 사용하였습니다.

> 연산자 끼워넣기
- 완전탐색 방식을 사용하여 모든 경우의 수를 탐색하였습니다.

> 음악프로그램
- 처음 풀이를 할 때 그저 모든 노드를 확인하면서 노드의 순서를 바꿔야 한다고 생각하여 어렵다고 느껴졌습니다.
- 각 노드의 앞에 위치해야 하는 노드의 수가 몇개인지를 먼저 카운트하고 이를 바탕으로 탐색하면서 노드의 카운트가 0이 될 때 정답 리스트에 삽입하였습니다.
- 정답 리스트가 전체 가수의 수와 크기가 같다면 정답으로 처리하였습니다. (아닌 경우는 사이클 또는 모든 가수가 포함되지 않은 경우이기 때문.)